### PR TITLE
氏名の部分検索機能の実装

### DIFF
--- a/backend-ts/src/employee/EmployeeDatabaseInMemory.ts
+++ b/backend-ts/src/employee/EmployeeDatabaseInMemory.ts
@@ -20,6 +20,6 @@ export class EmployeeDatabaseInMemory implements EmployeeDatabase {
         if (filterText === "") {
             return employees;
         }
-        return employees.filter(employee => employee.name === filterText);
+        return employees.filter(employee => employee.name.includes(filterText));
     }
 }


### PR DESCRIPTION
# 概要
氏名検索を部分一致で行えるようにバックエンド側の処理を変更を変更
# 詳細
元々`/api/employees`では渡された文字列(`filterText`j)と完全一致するものだけを返却していましたが、それを部分一致に変更しました。
具体的には`EmployeeDatabaseInMemory`の`getEmployees`関数で、`===`を使って`filterText`と一致するものを探していたのを`includes`関数を使って`filterText`を含むもの探すように変更しました