### PR TITLE
グローバルヘッダに自分が今どのページにいるのかの表示を追加

### DIFF
--- a/frontend/src/app/employee/page.tsx
+++ b/frontend/src/app/employee/page.tsx
@@ -4,7 +4,7 @@ import { Suspense } from 'react';
 
 export default function EmployeePage() {
   return (
-    <GlobalContainer>
+    <GlobalContainer pageName={"社員検索"}>
       { /* Mark EmployeeDetailsContainer as CSR */ }
       <Suspense>
         <EmployeeDetailsContainer />

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -3,7 +3,7 @@ import { GlobalContainer } from "@/components/GlobalContainer";
 
 export default function Home() {
   return (
-    <GlobalContainer>
+    <GlobalContainer pageName={"社員詳細"}>
       <SearchEmployees />
     </GlobalContainer>
   );

--- a/frontend/src/components/GlobalContainer.tsx
+++ b/frontend/src/components/GlobalContainer.tsx
@@ -3,13 +3,18 @@ import { VerticalSpacer } from "../components/VerticalSpacer";
 import { GlobalHeader } from "../components/GlobalHeader";
 import { GlobalFooter } from "../components/GlobalFooter";
 
-export function GlobalContainer({ children }: { children?: React.ReactNode }) {
+interface GlobalContainerProps {
+  children?: React.ReactNode;
+  pageName: string;
+}
+
+export function GlobalContainer({ children, pageName }: GlobalContainerProps) {
   return (
     <Container
       sx={{ display: "flex", flexDirection: "column", minHeight: "100vh" }}
     >
       <header>
-        <GlobalHeader title={"タレントマネジメントシステム"} />
+        <GlobalHeader title={`タレントマネジメントシステム  ${pageName}`} />
       </header>
 
       <VerticalSpacer height={32} />


### PR DESCRIPTION
# 概要
グローバルヘッダに、「社員検索」や「社員詳細」など、「自分が今どのページにいるのか」を表示する（例：「タレントマネジメントシステム 　社員検索」）

# 詳細
`GlobalHeader`コンポーネントに現在のページ名のパラメータ`pageName`を追加しました．