### PR TITLE
Task<2>: <ウィンドウタイトルに、「社員検索」や「社員詳細」など、「自分が今どのページにいるのか」を表示する機能を追加>

### DIFF
--- a/backend-ts/package-lock.json
+++ b/backend-ts/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.1.0",
       "license": "ISC",
       "dependencies": {
-        "io-ts": "^2.2.22"
+        "io-ts": "^2.2.22",
+        "node.js": "^0.0.1-security"
       },
       "devDependencies": {
         "@aws-sdk/client-dynamodb": "^3.788.0",
@@ -5415,6 +5416,11 @@
       "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/node.js": {
+      "version": "0.0.1-security",
+      "resolved": "https://registry.npmjs.org/node.js/-/node.js-0.0.1-security.tgz",
+      "integrity": "sha512-8tWQiyg/3ggdLTrtfgj/NxmZpC20eB1U5VNkqt2dbelpcr3NrfjpEE3DgifpBOCJ4Xu9Obvu8iju63ViQW3Hvg=="
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",

--- a/backend-ts/package.json
+++ b/backend-ts/package.json
@@ -24,6 +24,7 @@
     "typescript": "^5.8.3"
   },
   "dependencies": {
-    "io-ts": "^2.2.22"
+    "io-ts": "^2.2.22",
+    "node.js": "^0.0.1-security"
   }
 }

--- a/frontend/src/components/EmployeeDetails.tsx
+++ b/frontend/src/components/EmployeeDetails.tsx
@@ -1,7 +1,7 @@
 import PersonIcon from "@mui/icons-material/Person";
 import { Avatar, Box, Paper, Tab, Tabs, Typography } from "@mui/material";
 import { Employee } from "../models/Employee";
-import { useCallback, useState } from "react";
+import { useCallback, useState, useEffect } from "react";
 
 const tabPanelValue = {
   basicInfo: "基本情報",
@@ -33,6 +33,10 @@ export type EmployeeDetailsProps = {
 };
 
 export function EmployeeDetails(prop: EmployeeDetailsProps) {
+  useEffect(() => {
+    document.title = "タレントマネジメントシステム - 社員詳細";
+  }, []);
+
   const [selectedTabValue, setSelectedTabValue] =
     useState<TabPanelValue>("basicInfo");
   const employee = prop.employee;

--- a/frontend/src/components/EmployeeListItem.tsx
+++ b/frontend/src/components/EmployeeListItem.tsx
@@ -2,6 +2,7 @@ import PersonIcon from "@mui/icons-material/Person";
 
 import { Avatar, Box, Card, CardContent, Typography } from "@mui/material";
 import { Employee } from "../models/Employee";
+import { useEffect } from "react";
 import Link from "next/link";
 
 export type EmployeeListItemProps = {

--- a/frontend/src/components/SearchEmployees.tsx
+++ b/frontend/src/components/SearchEmployees.tsx
@@ -1,9 +1,13 @@
 "use client";
 import { Paper, TextField } from "@mui/material";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { EmployeeListContainer } from "./EmployeeListContainer";
 
 export function SearchEmployees() {
+  useEffect(() => {
+    document.title = "タレントマネジメントシステム - 社員検索";
+  }, []);
+
   const [searchKeyword, setSearchKeyword] = useState("");
   return (
     <Paper


### PR DESCRIPTION
SearchEmployees.tsxとEmployeeDetails.tsxにdocument.titleを用いてウィンドウタイトルにページ名を反映させるようにしました。CSRのページにはuseEffectをかませて反映させています。レビューお願いします。