### PR TITLE
Task<2’>:<ウィンドウタイトルへのページ名の表示機能の修正>

### DIFF
--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -14,7 +14,7 @@ const geistMono = Geist_Mono({
 });
 
 export const metadata: Metadata = {
-  title: "タレントマネジメントシステム",
+  //title: "タレントマネジメントシステム",
   description: "シンプルなタレントマネジメントシステム",
 };
 

--- a/frontend/src/components/EmployeeDetails.tsx
+++ b/frontend/src/components/EmployeeDetails.tsx
@@ -1,7 +1,7 @@
 import PersonIcon from "@mui/icons-material/Person";
 import { Avatar, Box, Paper, Tab, Tabs, Typography } from "@mui/material";
 import { Employee } from "../models/Employee";
-import { useCallback, useState, useEffect } from "react";
+import { useCallback, useState } from "react";
 
 const tabPanelValue = {
   basicInfo: "基本情報",
@@ -33,10 +33,6 @@ export type EmployeeDetailsProps = {
 };
 
 export function EmployeeDetails(prop: EmployeeDetailsProps) {
-  useEffect(() => {
-    document.title = "タレントマネジメントシステム - 社員詳細";
-  }, []);
-
   const [selectedTabValue, setSelectedTabValue] =
     useState<TabPanelValue>("basicInfo");
   const employee = prop.employee;
@@ -49,45 +45,49 @@ export function EmployeeDetails(prop: EmployeeDetailsProps) {
   );
 
   return (
-    <Paper sx={{ p: 2 }}>
-      <Box
-        display={"flex"}
-        flexDirection="column"
-        alignItems="flex-start"
-        gap={1}
-      >
+    <>
+      <title>タレントマネジメントシステム - 社員詳細</title>
+
+      <Paper sx={{ p: 2 }}>
         <Box
-          display="flex"
-          flexDirection="row"
-          alignItems="center"
-          p={2}
-          gap={2}
+          display={"flex"}
+          flexDirection="column"
+          alignItems="flex-start"
+          gap={1}
         >
-          <Avatar sx={{ width: 128, height: 128 }}>
-            <PersonIcon sx={{ fontSize: 128 }} />
-          </Avatar>
-          <Typography variant="h5">{employee.name}</Typography>
-        </Box>
-        <Box sx={{ borderBottom: 1, borderColor: "divider", width: "100%" }}>
-          <Tabs value={selectedTabValue} onChange={handleTabValueChange}>
-            <Tab label={tabPanelValue.basicInfo} value={"basicInfo"} />
-            <Tab label={tabPanelValue.others} value={"others"} />
-          </Tabs>
-        </Box>
-
-        <TabContent value={"basicInfo"} selectedValue={selectedTabValue}>
-          <Box p={2} display="flex" flexDirection="column" gap={1}>
-            <Typography variant="h6">基本情報</Typography>
-            <Typography>年齢：{employee.age}歳</Typography>
+          <Box
+            display="flex"
+            flexDirection="row"
+            alignItems="center"
+            p={2}
+            gap={2}
+          >
+            <Avatar sx={{ width: 128, height: 128 }}>
+              <PersonIcon sx={{ fontSize: 128 }} />
+            </Avatar>
+            <Typography variant="h5">{employee.name}</Typography>
           </Box>
-        </TabContent>
-
-        <TabContent value={"others"} selectedValue={selectedTabValue}>
-          <Box p={2} display="flex" flexDirection="column" gap={1}>
-            <Typography variant="h6">その他</Typography>
+          <Box sx={{ borderBottom: 1, borderColor: "divider", width: "100%" }}>
+            <Tabs value={selectedTabValue} onChange={handleTabValueChange}>
+              <Tab label={tabPanelValue.basicInfo} value={"basicInfo"} />
+              <Tab label={tabPanelValue.others} value={"others"} />
+            </Tabs>
           </Box>
-        </TabContent>
-      </Box>
-    </Paper>
+
+          <TabContent value={"basicInfo"} selectedValue={selectedTabValue}>
+            <Box p={2} display="flex" flexDirection="column" gap={1}>
+              <Typography variant="h6">基本情報</Typography>
+              <Typography>年齢：{employee.age}歳</Typography>
+            </Box>
+          </TabContent>
+
+          <TabContent value={"others"} selectedValue={selectedTabValue}>
+            <Box p={2} display="flex" flexDirection="column" gap={1}>
+              <Typography variant="h6">その他</Typography>
+            </Box>
+          </TabContent>
+        </Box>
+      </Paper>
+    </>
   );
 }

--- a/frontend/src/components/SearchEmployees.tsx
+++ b/frontend/src/components/SearchEmployees.tsx
@@ -1,33 +1,33 @@
 "use client";
 import { Paper, TextField } from "@mui/material";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { EmployeeListContainer } from "./EmployeeListContainer";
 
 export function SearchEmployees() {
-  useEffect(() => {
-    document.title = "タレントマネジメントシステム - 社員検索";
-  }, []);
-
   const [searchKeyword, setSearchKeyword] = useState("");
   return (
-    <Paper
-      sx={{
-        display: "flex",
-        flexDirection: "column",
-        gap: 2,
-        flex: 1,
-        p: 2,
-      }}
-    >
-      <TextField
-        placeholder="検索キーワードを入力してください"
-        value={searchKeyword}
-        onChange={(e) => setSearchKeyword(e.target.value)}
-      />
-      <EmployeeListContainer
-        key="employeesContainer"
-        filterText={searchKeyword}
-      />
-    </Paper>
+    <>
+      <title>タレントマネジメントシステム - 社員検索</title>
+
+      <Paper
+        sx={{
+          display: "flex",
+          flexDirection: "column",
+          gap: 2,
+          flex: 1,
+          p: 2,
+        }}
+      >
+        <TextField
+          placeholder="検索キーワードを入力してください"
+          value={searchKeyword}
+          onChange={(e) => setSearchKeyword(e.target.value)}
+        />
+        <EmployeeListContainer
+          key="employeesContainer"
+          filterText={searchKeyword}
+        />
+      </Paper>
+    </>
   );
 }


### PR DESCRIPTION
初回ロード時にウィンドウタイトルが適切に変更されないバグを修正しました。SSR環境でdocumentが無視されていることが原因と思われたので、JSX中でtitleヘッダを用いて表示するようにしました。レビューお願いします。