### PR TITLE
ヘッダーに表示するページ名が検索と詳細で逆になっていたのを修正

### DIFF
--- a/frontend/src/app/employee/page.tsx
+++ b/frontend/src/app/employee/page.tsx
@@ -4,7 +4,7 @@ import { Suspense } from 'react';
 
 export default function EmployeePage() {
   return (
-    <GlobalContainer pageName={"社員検索"}>
+    <GlobalContainer pageName={"社員詳細"}>
       { /* Mark EmployeeDetailsContainer as CSR */ }
       <Suspense>
         <EmployeeDetailsContainer />

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -3,7 +3,7 @@ import { GlobalContainer } from "@/components/GlobalContainer";
 
 export default function Home() {
   return (
-    <GlobalContainer pageName={"社員詳細"}>
+    <GlobalContainer pageName={"社員検索"}>
       <SearchEmployees />
     </GlobalContainer>
   );


### PR DESCRIPTION
# 概要
ヘッダーに表示するページ名が検索と詳細で逆になっていたのを修正しました

# 詳細
検索ページでヘッダーに`社員詳細`，詳細ページで`社員検索`と表示されていたので修正しました．
