### PR TITLE
Task<4>:社員詳細画面に、「検索画面に戻る」リンクを追加する

### DIFF
--- a/frontend/src/app/employee/page.tsx
+++ b/frontend/src/app/employee/page.tsx
@@ -1,14 +1,18 @@
+import { BackButton } from "@/components/BackButton";
 import { EmployeeDetailsContainer } from "@/components/EmployeeDetailsContainer";
 import { GlobalContainer } from "@/components/GlobalContainer";
-import { Suspense } from 'react';
+import { Suspense } from "react";
 
 export default function EmployeePage() {
   return (
-    <GlobalContainer pageName={"社員検索"}>
-      { /* Mark EmployeeDetailsContainer as CSR */ }
-      <Suspense>
-        <EmployeeDetailsContainer />
-      </Suspense>
-    </GlobalContainer>
+    <>
+      <GlobalContainer pageName={"社員検索"}>
+        {/* Mark EmployeeDetailsContainer as CSR */}
+        <Suspense>
+          <EmployeeDetailsContainer />
+        </Suspense>
+        <BackButton text={"検索画面に戻る"} />
+      </GlobalContainer>
+    </>
   );
 }

--- a/frontend/src/components/BackButton.tsx
+++ b/frontend/src/components/BackButton.tsx
@@ -1,0 +1,16 @@
+"use client";
+import { Box, Button } from "@mui/material";
+
+export interface ButtonProps {
+  text: string;
+}
+
+export function BackButton({ text }: ButtonProps) {
+  return (
+    <Box sx={{ display: "flex", justifyContent: "flex-end" }}>
+      <Button sx={{ margin: 2 }} onClick={() => window.history.back()}>
+        {text}
+      </Button>
+    </Box>
+  );
+}


### PR DESCRIPTION
# 概要
社員詳細画面の右下に検索一覧に戻るボタンを追加しました。

# 詳細
戻るボタンのコンポーネントを作成し、社員詳細画面の`page.tsx`に追加

# 生成AIの利用について
特になし

<img width="1281" height="858" alt="image" src="https://github.com/user-attachments/assets/2b6365a8-0e58-4658-8947-6ef603f6d88f" />