### PR TITLE
Task<13>: <ダークモード対応>

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -27,3 +27,15 @@ a {
   color: inherit;
   text-decoration: none;
 }
+
+.Mode.dark {
+  background-color: #3a383b;
+  color: #e1e1e1;
+  transition: all 0.5s;
+}
+
+.Mode.light {
+  background-color: #f8f3ef;
+  color: #353535;
+  transition: all 0.5s;
+}

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -2,6 +2,8 @@ import type { Metadata } from "next";
 import { AppRouterCacheProvider } from "@mui/material-nextjs/v15-appRouter";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
+import React from "react";
+import { ThemeProvider } from "@/components/ThemeContext";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -26,7 +28,9 @@ export default function RootLayout({
   return (
     <html lang="ja">
       <body className={`${geistSans.variable} ${geistMono.variable}`}>
-        <AppRouterCacheProvider>{children}</AppRouterCacheProvider>
+        <ThemeProvider>
+          <AppRouterCacheProvider>{children}</AppRouterCacheProvider>
+        </ThemeProvider>
       </body>
     </html>
   );

--- a/frontend/src/components/DarkModeBar.tsx
+++ b/frontend/src/components/DarkModeBar.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { FormControlLabel, Switch } from "@mui/material";
+import { useTheme } from "./ThemeContext";
+
+function DarkModeBar() {
+  const { mode, setMode } = useTheme();
+
+  const handleChangeMode = () => {
+    setMode(mode == "light" ? "dark" : "light");
+  };
+
+  return (
+    <>
+      <FormControlLabel
+        control={
+          <Switch
+            checked={mode == "dark"}
+            onChange={handleChangeMode}
+            color="primary"
+          />
+        }
+        label={mode == "dark" ? "🌙" : "💡"}
+      />
+    </>
+  );
+}
+
+export default DarkModeBar;

--- a/frontend/src/components/GlobalHeader.tsx
+++ b/frontend/src/components/GlobalHeader.tsx
@@ -1,6 +1,7 @@
 import { AppBar, Box, Toolbar, Typography } from "@mui/material";
 import PeopleIcon from "@mui/icons-material/People";
 import Link from "next/link";
+import DarkModeBar from "./DarkModeBar";
 
 export interface GlobalHeaderProps {
   title: string;
@@ -25,6 +26,9 @@ export function GlobalHeader({ title }: GlobalHeaderProps) {
               {title}
             </Typography>
           </Link>
+
+          <Box sx={{ flexGrow: 1 }} />
+          <DarkModeBar />
         </Toolbar>
       </AppBar>
     </Box>

--- a/frontend/src/components/ThemeContext.tsx
+++ b/frontend/src/components/ThemeContext.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { createContext, useState, ReactNode, useContext } from "react";
+
+export type ThemeMode = "light" | "dark";
+
+const ThemeContext = createContext<{
+  mode: ThemeMode;
+  setMode: (mode: ThemeMode) => void;
+} | null>(null);
+
+export function ThemeProvider({ children }: { children: ReactNode }) {
+  const [mode, setMode] = useState<ThemeMode>("light");
+
+  return (
+    <ThemeContext.Provider value={{ mode, setMode }}>
+      <div className={`Mode ${mode}`}>{children}</div>
+    </ThemeContext.Provider>
+  );
+}
+
+export function useTheme() {
+  const context = useContext(ThemeContext);
+  if (!context) {
+    throw new Error("useTheme must be used within ThemeProvider");
+  }
+  return context;
+}


### PR DESCRIPTION
# 概要
グローバルヘッダーのトグルスイッチでダークモードに変更できる機能を追加しました。
# 詳細
トグルスイッチを設計したDarkModeBar.tsxコンポーネント, グローバルに状態(light or dark mode)を扱うThemeContext.tsxの２つのファイルを新規に作成し、'src/app/employee/layout.tsx'に自作のテーマプロバイダーを適用しました。
背景のみダークモードになるように設計しましたが、改善案等あったらお願いします。