### PR TITLE
Task 8: 検索結果の表示形式の切り替え

### DIFF
--- a/frontend/src/components/EmployeeListContainer.tsx
+++ b/frontend/src/components/EmployeeListContainer.tsx
@@ -60,7 +60,11 @@ export function EmployeeListContainer({
 
   if (data != null) {
     return data.map((employee) => (
-      <EmployeeListItem employee={employee} key={employee.id} viewMode={viewMode} />
+      <EmployeeListItem
+        employee={employee}
+        key={employee.id}
+        viewMode={viewMode}
+      />
     ));
   }
 

--- a/frontend/src/components/EmployeeListContainer.tsx
+++ b/frontend/src/components/EmployeeListContainer.tsx
@@ -5,11 +5,13 @@ import * as t from "io-ts";
 import { isLeft } from "fp-ts/Either";
 import { EmployeeListItem } from "./EmployeeListItem";
 import { Employee, EmployeeT } from "../models/Employee";
+import { Grid } from "@mui/material";
 
 export type EmployeesContainerProps = {
   filterText: string;
   affiliationFilter: string;
   positionFilter: string;
+  viewMode: "list" | "card";
 };
 
 const EmployeesT = t.array(EmployeeT);
@@ -27,7 +29,7 @@ const employeesFetcher = async (url: string): Promise<Employee[]> => {
   return decoded.right;
 };
 
-export function EmployeeListContainer({ filterText, affiliationFilter, positionFilter }: EmployeesContainerProps) {
+export function EmployeeListContainer({ filterText, affiliationFilter, positionFilter, viewMode }: EmployeesContainerProps) {
   const encodedFilterText = encodeURIComponent(filterText);
   const { data, error, isLoading } = useSWR<Employee[], Error>(
     `/api/employees?filterText=${encodedFilterText}&affiliation=${affiliationFilter}&position=${positionFilter}`,
@@ -38,11 +40,25 @@ export function EmployeeListContainer({ filterText, affiliationFilter, positionF
       console.error(`Failed to fetch employees filtered by filterText`, error);
     }
   }, [error, filterText]);
+
+  if (data != null && viewMode === "card") {
+    return (
+      <Grid container spacing={2}>
+        {data.map((employee) => (
+          <Grid key={employee.id} size={{ xs: 12, sm: 6, md: 4 }}>
+            <EmployeeListItem employee={employee} viewMode={viewMode} />
+          </Grid>
+        ))}
+      </Grid>
+    );
+  }
+
   if (data != null) {
     return data.map((employee) => (
-      <EmployeeListItem employee={employee} key={employee.id} />
+      <EmployeeListItem employee={employee} key={employee.id} viewMode={viewMode} />
     ));
   }
+
   if (isLoading) {
     return <p>Loading employees...</p>;
   }

--- a/frontend/src/components/EmployeeListItem.tsx
+++ b/frontend/src/components/EmployeeListItem.tsx
@@ -9,7 +9,10 @@ export type EmployeeListItemProps = {
   viewMode: "list" | "card";
 };
 
-export function EmployeeListItem({ employee, viewMode }: EmployeeListItemProps) {
+export function EmployeeListItem({
+  employee,
+  viewMode,
+}: EmployeeListItemProps) {
   return (
     <Link
       href={`/employee?id=${employee.id}`}
@@ -24,7 +27,12 @@ export function EmployeeListItem({ employee, viewMode }: EmployeeListItemProps) 
         }}
       >
         <CardContent>
-          <Box display="flex" flexDirection={viewMode === "card" ? "column" : "row"} alignItems="center" gap={2}>
+          <Box
+            display="flex"
+            flexDirection={viewMode === "card" ? "column" : "row"}
+            alignItems="center"
+            gap={2}
+          >
             <Avatar sx={{ width: 48, height: 48 }}>
               <PersonIcon sx={{ fontSize: 48 }} />
             </Avatar>

--- a/frontend/src/components/EmployeeListItem.tsx
+++ b/frontend/src/components/EmployeeListItem.tsx
@@ -2,15 +2,14 @@ import PersonIcon from "@mui/icons-material/Person";
 
 import { Avatar, Box, Card, CardContent, Typography } from "@mui/material";
 import { Employee } from "../models/Employee";
-import { useEffect } from "react";
 import Link from "next/link";
 
 export type EmployeeListItemProps = {
   employee: Employee;
+  viewMode: "list" | "card";
 };
 
-export function EmployeeListItem(prop: EmployeeListItemProps) {
-  const employee = prop.employee;
+export function EmployeeListItem({ employee, viewMode }: EmployeeListItemProps) {
   return (
     <Link
       href={`/employee?id=${employee.id}`}
@@ -25,7 +24,7 @@ export function EmployeeListItem(prop: EmployeeListItemProps) {
         }}
       >
         <CardContent>
-          <Box display="flex" flexDirection="row" alignItems="center" gap={2}>
+          <Box display="flex" flexDirection={viewMode === "card" ? "column" : "row"} alignItems="center" gap={2}>
             <Avatar sx={{ width: 48, height: 48 }}>
               <PersonIcon sx={{ fontSize: 48 }} />
             </Avatar>

--- a/frontend/src/components/SearchEmployees.tsx
+++ b/frontend/src/components/SearchEmployees.tsx
@@ -1,12 +1,20 @@
 "use client";
-import { Grid, Paper, TextField } from "@mui/material";
+import { Grid, Paper, TextField, ToggleButton, ToggleButtonGroup } from "@mui/material";
 import { useState } from "react";
 import { EmployeeListContainer } from "./EmployeeListContainer";
+import FormatListBulletedIcon from '@mui/icons-material/FormatListBulleted';
+import ViewModuleIcon from '@mui/icons-material/ViewModule';
 
 export function SearchEmployees() {
   const [searchKeyword, setSearchKeyword] = useState("");
   const [affiliationFilter, setAffiliationFilter] = useState("");
   const [positionFilter, setPositionFilter] = useState("");
+
+  const [viewMode, setViewMode] = useState<"list" | "card">("list");
+
+  const handleChangeViewMode = (_: React.MouseEvent<HTMLElement>, value: string) => {
+    setViewMode(value as "list" | "card");
+  };
 
   return (
     <>
@@ -26,29 +34,44 @@ export function SearchEmployees() {
           value={searchKeyword}
           onChange={(e) => setSearchKeyword(e.target.value)}
         />
-      <Grid container spacing={2}>
-        <Grid size={{ sm: 12, md: 6 }}>
-          <TextField
-            fullWidth
-            placeholder="所属を入力してください"
-            value={affiliationFilter}
-            onChange={(e) => setAffiliationFilter(e.target.value)}
-          />
+        <Grid container spacing={2}>
+          <Grid size={{ sm: 12, md: 6 }}>
+            <TextField
+              fullWidth
+              placeholder="所属を入力してください"
+              value={affiliationFilter}
+              onChange={(e) => setAffiliationFilter(e.target.value)}
+            />
+          </Grid>
+          <Grid size={{ sm: 12, md: 6 }}>
+            <TextField
+              fullWidth
+              placeholder="役職を入力してください"
+              value={positionFilter}
+              onChange={(e) => setPositionFilter(e.target.value)}
+            />
+          </Grid>
         </Grid>
-        <Grid size={{ sm: 12, md: 6 }}>
-          <TextField
-            fullWidth
-            placeholder="役職を入力してください"
-            value={positionFilter}
-            onChange={(e) => setPositionFilter(e.target.value)}
-          />
-        </Grid>
-      </Grid>
+
+        <ToggleButtonGroup
+          exclusive
+          value={viewMode}
+          onChange={handleChangeViewMode}
+        >
+          <ToggleButton value="list" aria-label="list">
+            <FormatListBulletedIcon />
+          </ToggleButton>
+          <ToggleButton value="card" aria-label="card">
+            <ViewModuleIcon />
+          </ToggleButton>
+        </ToggleButtonGroup>
+
         <EmployeeListContainer
           key="employeesContainer"
           filterText={searchKeyword}
-        affiliationFilter={affiliationFilter}
-        positionFilter={positionFilter}
+          affiliationFilter={affiliationFilter}
+          positionFilter={positionFilter}
+          viewMode={viewMode}
         />
       </Paper>
     </>

--- a/frontend/src/components/SearchEmployees.tsx
+++ b/frontend/src/components/SearchEmployees.tsx
@@ -1,9 +1,15 @@
 "use client";
-import { Grid, Paper, TextField, ToggleButton, ToggleButtonGroup } from "@mui/material";
+import {
+  Grid,
+  Paper,
+  TextField,
+  ToggleButton,
+  ToggleButtonGroup,
+} from "@mui/material";
 import { useState } from "react";
 import { EmployeeListContainer } from "./EmployeeListContainer";
-import FormatListBulletedIcon from '@mui/icons-material/FormatListBulleted';
-import ViewModuleIcon from '@mui/icons-material/ViewModule';
+import FormatListBulletedIcon from "@mui/icons-material/FormatListBulleted";
+import ViewModuleIcon from "@mui/icons-material/ViewModule";
 
 export function SearchEmployees() {
   const [searchKeyword, setSearchKeyword] = useState("");
@@ -12,7 +18,10 @@ export function SearchEmployees() {
 
   const [viewMode, setViewMode] = useState<"list" | "card">("list");
 
-  const handleChangeViewMode = (_: React.MouseEvent<HTMLElement>, value: string) => {
+  const handleChangeViewMode = (
+    _: React.MouseEvent<HTMLElement>,
+    value: string
+  ) => {
     setViewMode(value as "list" | "card");
   };
 


### PR DESCRIPTION
# 概要
カード形式の表示を実装し、リスト形式と切り替えを可能にする

# 詳細
リストとカードの切り替えボタンを追加し，カードを選択した場合は横並びに表示するようにしました．  
カードのデザインはリストで横並びだったものを縦並びにしただけなので，何かほかに良いアイデアがあれば変更してください．  

<img width="1250" height="266" alt="image" src="https://github.com/user-attachments/assets/5e540d73-dff0-4312-a458-d1238e6d8ef0" />
