### PR TITLE
概要の表示

### DIFF
--- a/frontend/src/components/EmployeeListItem.tsx
+++ b/frontend/src/components/EmployeeListItem.tsx
@@ -1,8 +1,15 @@
 import PersonIcon from "@mui/icons-material/Person";
 
-import { Avatar, Box, Card, CardContent, Typography } from "@mui/material";
-import { Employee } from "../models/Employee";
+import {
+  Avatar,
+  Box,
+  Card,
+  CardContent,
+  Chip,
+  Typography,
+} from "@mui/material";
 import Link from "next/link";
+import { Employee } from "../models/Employee";
 
 export type EmployeeListItemProps = {
   employee: Employee;
@@ -36,8 +43,11 @@ export function EmployeeListItem({
             <Avatar sx={{ width: 48, height: 48 }}>
               <PersonIcon sx={{ fontSize: 48 }} />
             </Avatar>
-            <Box display="flex" flexDirection="column">
-              <Typography>{employee.name}</Typography>
+            <Box display="flex" flexDirection="row" gap={1}>
+              <Chip label={employee.affiliation} variant="outlined" />
+              <Chip label={employee.position} variant="outlined" />
+              <Chip label={employee.name} variant="outlined" />
+              <Chip label={`${employee.age}歳`} variant="outlined" />
             </Box>
           </Box>
         </CardContent>

--- a/frontend/src/components/EmployeeListItem.tsx
+++ b/frontend/src/components/EmployeeListItem.tsx
@@ -1,13 +1,6 @@
 import PersonIcon from "@mui/icons-material/Person";
 
-import {
-  Avatar,
-  Box,
-  Card,
-  CardContent,
-  Chip,
-  Typography,
-} from "@mui/material";
+import { Avatar, Box, Card, CardContent, Chip } from "@mui/material";
 import Link from "next/link";
 import { Employee } from "../models/Employee";
 

--- a/frontend/src/components/EmployeeListItem.tsx
+++ b/frontend/src/components/EmployeeListItem.tsx
@@ -1,6 +1,13 @@
 import PersonIcon from "@mui/icons-material/Person";
 
-import { Avatar, Box, Card, CardContent, Chip } from "@mui/material";
+import {
+  Avatar,
+  Box,
+  Card,
+  CardContent,
+  Chip,
+  Typography,
+} from "@mui/material";
 import Link from "next/link";
 import { Employee } from "../models/Employee";
 
@@ -36,11 +43,24 @@ export function EmployeeListItem({
             <Avatar sx={{ width: 48, height: 48 }}>
               <PersonIcon sx={{ fontSize: 48 }} />
             </Avatar>
-            <Box display="flex" flexDirection="row" gap={1} flexWrap="wrap">
-              <Chip label={employee.affiliation} variant="outlined" />
-              <Chip label={employee.position} variant="outlined" />
-              <Chip label={employee.name} variant="outlined" />
-              <Chip label={`${employee.age}歳`} variant="outlined" />
+            <Box
+              display="flex"
+              flexDirection="column"
+              gap={1}
+              alignItems={viewMode === "card" ? "center" : "flex-start"}
+            >
+              <Typography>{employee.name}</Typography>
+              <Box
+                display="flex"
+                flexDirection="row"
+                gap={1}
+                flexWrap="wrap"
+                alignItems="center"
+              >
+                <Chip label={employee.affiliation} variant="outlined" />
+                <Chip label={employee.position} variant="outlined" />
+                <Chip label={`${employee.age}歳`} variant="outlined" />
+              </Box>
             </Box>
           </Box>
         </CardContent>

--- a/frontend/src/components/EmployeeListItem.tsx
+++ b/frontend/src/components/EmployeeListItem.tsx
@@ -43,7 +43,7 @@ export function EmployeeListItem({
             <Avatar sx={{ width: 48, height: 48 }}>
               <PersonIcon sx={{ fontSize: 48 }} />
             </Avatar>
-            <Box display="flex" flexDirection="row" gap={1}>
+            <Box display="flex" flexDirection="row" gap={1} flexWrap="wrap">
               <Chip label={employee.affiliation} variant="outlined" />
               <Chip label={employee.position} variant="outlined" />
               <Chip label={employee.name} variant="outlined" />


### PR DESCRIPTION
# 概要

検索した時に名前だけでなく、概要も分かるように

# 詳細

検索結果に表示される従業員の情報を、名前だけでなく所属や役職、年齢などの概要も含めて表示するように変更しました。