### PR TITLE
Task 5: 社員の追加機能を追加

### DIFF
--- a/backend-ts/src/employee/Employee.ts
+++ b/backend-ts/src/employee/Employee.ts
@@ -9,3 +9,12 @@ export const EmployeeT = t.type({
 });
 
 export type Employee = t.TypeOf<typeof EmployeeT>;
+
+export const EmployeeRegisterT = t.type({
+    name: t.string,
+    age: t.number,
+    affiliation: t.string,
+    position: t.string,
+});
+
+export type EmployeeRegister = t.TypeOf<typeof EmployeeRegisterT>;

--- a/backend-ts/src/employee/EmployeeDatabase.ts
+++ b/backend-ts/src/employee/EmployeeDatabase.ts
@@ -1,6 +1,7 @@
-import { Employee } from "./Employee";
+import { Employee, EmployeeRegister } from "./Employee";
 
 export interface EmployeeDatabase {
     getEmployee(id: string): Promise<Employee | undefined>
     getEmployees(filterText: string, affiliation: string, position: string): Promise<Employee[]>
+    saveEmployee(employeeRegister: EmployeeRegister): Promise<Employee>
 }

--- a/backend-ts/src/employee/EmployeeDatabaseDynamoDB.ts
+++ b/backend-ts/src/employee/EmployeeDatabaseDynamoDB.ts
@@ -1,4 +1,4 @@
-import { DynamoDBClient, GetItemCommand, GetItemCommandInput, ScanCommand, ScanCommandInput } from "@aws-sdk/client-dynamodb";
+import { DynamoDBClient, GetItemCommand, GetItemCommandInput, PutItemCommand, PutItemCommandInput, ScanCommand, ScanCommandInput } from "@aws-sdk/client-dynamodb";
 import { isLeft } from "fp-ts/Either";
 import { EmployeeDatabase } from "./EmployeeDatabase";
 import { Employee, EmployeeT } from "./Employee";
@@ -65,6 +65,51 @@ export class EmployeeDatabaseDynamoDB implements EmployeeDatabase {
                     return [decoded.right];
                 }
             });
+    }
+
+    private async getMaxId(): Promise<number> {
+        const input: ScanCommandInput = {
+            TableName: this.tableName,
+            ProjectionExpression: "id",
+        };
+        const output = await this.client.send(new ScanCommand(input));
+        const items = output.Items;
+        if (items == null || items.length === 0) {
+            return 0;
+        }
+
+       	const maxId = Math.max(...items.filter((item): item is { id: { S: string } }  => item["id"].S != null).map(item => parseInt(item["id"].S, 10)))
+
+      	return maxId;
+		}
+
+    async saveEmployee(employee: Employee): Promise<Employee> {
+				if (!employee.id) {
+						const maxId = await this.getMaxId();
+						employee.id = (maxId + 1).toString();
+				}
+        const input: PutItemCommandInput = {
+						TableName: this.tableName,
+						Item: {
+								id: { S: employee.id },
+								name: { S: employee.name },
+								age: { N: employee.age.toString() },
+								affiliation: { S: employee.affiliation },
+								position: { S: employee.position },
+						},
+				}
+
+        await this.client.send(new PutItemCommand(input));
+        const savedEmployee = await this.getEmployee(employee.id);
+				
+        if (savedEmployee == undefined) {
+            throw new Error(`Failed to save employee ${employee.id}`);
+        }
+        const decoded = EmployeeT.decode(savedEmployee);
+        if (isLeft(decoded)) {
+            throw new Error(`Saved employee ${employee.id} is missing some fields. ${JSON.stringify(savedEmployee)}`);
+        }
+        return employee;
     }
 }
 

--- a/backend-ts/src/employee/EmployeeDatabaseInMemory.ts
+++ b/backend-ts/src/employee/EmployeeDatabaseInMemory.ts
@@ -1,5 +1,5 @@
 import { EmployeeDatabase } from "./EmployeeDatabase";
-import { Employee } from "./Employee";
+import { Employee, EmployeeRegister } from "./Employee";
 
 export class EmployeeDatabaseInMemory implements EmployeeDatabase {
     private employees: Map<string, Employee>
@@ -31,5 +31,21 @@ export class EmployeeDatabaseInMemory implements EmployeeDatabase {
         }
 
         return employees;
+    }
+
+    private async getMaxId(): Promise<number> {
+        if (this.employees.size === 0) {
+            return 0;
+        }
+        const maxID = Array.from(this.employees.keys()).map(id => parseInt(id)).reduce((max, id) => max > id ? max : id, 0);
+
+        return maxID;
+    }
+
+    async saveEmployee(employeeRegister: EmployeeRegister): Promise<Employee> {
+        const id = (await this.getMaxId() + 1).toString();
+        const employee = { id,  ...employeeRegister };
+        this.employees.set(employee.id, employee);
+        return employee;
     }
 }

--- a/frontend/src/app/employee/register/page.tsx
+++ b/frontend/src/app/employee/register/page.tsx
@@ -1,0 +1,11 @@
+import { EmployeeRegisterContainer } from "@/components/EmployeeRegisterContainer";
+import { GlobalContainer } from "@/components/GlobalContainer";
+
+
+export default function EmployeeRegisterPage() {
+  return (
+    <GlobalContainer pageName={"社員登録"}>
+      <EmployeeRegisterContainer />
+    </GlobalContainer>
+  );
+}

--- a/frontend/src/app/employee/register/page.tsx
+++ b/frontend/src/app/employee/register/page.tsx
@@ -1,7 +1,6 @@
 import { EmployeeRegisterContainer } from "@/components/EmployeeRegisterContainer";
 import { GlobalContainer } from "@/components/GlobalContainer";
 
-
 export default function EmployeeRegisterPage() {
   return (
     <GlobalContainer pageName={"社員登録"}>

--- a/frontend/src/components/EmployeeRegisterContainer.tsx
+++ b/frontend/src/components/EmployeeRegisterContainer.tsx
@@ -1,0 +1,64 @@
+"use client"
+import { EmployeeRegister, EmployeeRegisterT, EmployeeT } from "@/models/Employee";
+import { isLeft } from "fp-ts/Either";
+import { EmployeeRegisterItem } from "./EmployeeRegisterItem";
+import { Box } from "@mui/material";
+
+export interface EmployeeRegisterContainerProps {
+  employeeRegister: EmployeeRegister
+}
+
+async function calculateSha256HashBrowser(data: string): Promise<string> {
+  const textEncoder = new TextEncoder();
+  const dataBuffer = textEncoder.encode(data); // 文字列をUint8Arrayにエンコード
+
+  // crypto.subtle.digest でSHA-256ハッシュを計算
+  const hashBuffer = await crypto.subtle.digest("SHA-256", dataBuffer);
+
+  // ArrayBufferを16進数文字列に変換
+  const hashArray = Array.from(new Uint8Array(hashBuffer));
+  const hexHash = hashArray
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+
+  return hexHash;
+}
+
+const employeeRegisterFetcher = async (props: EmployeeRegisterContainerProps): Promise<void> => {
+  const result = EmployeeRegisterT.decode(props.employeeRegister);
+  if (isLeft(result)) {
+    throw new Error(`Failed to decode employee register ${JSON.stringify(props)}`);
+  }
+  const reqBody = JSON.stringify(result.right);
+  const hashedBody = await calculateSha256HashBrowser(reqBody);
+  const request = new Request("/api/employees/register", {
+    method: "POST",
+    body: reqBody,
+    headers: {
+      "Content-Type": "application/json",
+      "x-amz-content-sha256": hashedBody,
+    },
+  });
+
+  const response = await fetch(request);
+  if (!response.ok) {
+    throw new Error(`Failed to register employee at ${request.url}`);
+  }
+
+  const body = await response.json();
+  const decoded = EmployeeT.decode(body);
+  if (isLeft(decoded)) {
+    throw new Error(`Failed to decode registered employee ${JSON.stringify(body)}`);
+  }
+  alert("登録が完了しました");
+  window.location.href = `/`
+}
+
+export function EmployeeRegisterContainer() {
+
+  return (
+    <Box>
+      <EmployeeRegisterItem onSubmit={employeeRegisterFetcher}/>
+    </Box>
+  )
+}

--- a/frontend/src/components/EmployeeRegisterContainer.tsx
+++ b/frontend/src/components/EmployeeRegisterContainer.tsx
@@ -1,11 +1,15 @@
-"use client"
-import { EmployeeRegister, EmployeeRegisterT, EmployeeT } from "@/models/Employee";
+"use client";
+import {
+  EmployeeRegister,
+  EmployeeRegisterT,
+  EmployeeT,
+} from "@/models/Employee";
 import { isLeft } from "fp-ts/Either";
 import { EmployeeRegisterItem } from "./EmployeeRegisterItem";
 import { Box } from "@mui/material";
 
 export interface EmployeeRegisterContainerProps {
-  employeeRegister: EmployeeRegister
+  employeeRegister: EmployeeRegister;
 }
 
 async function calculateSha256HashBrowser(data: string): Promise<string> {
@@ -24,10 +28,14 @@ async function calculateSha256HashBrowser(data: string): Promise<string> {
   return hexHash;
 }
 
-const employeeRegisterFetcher = async (props: EmployeeRegisterContainerProps): Promise<void> => {
+const employeeRegisterFetcher = async (
+  props: EmployeeRegisterContainerProps
+): Promise<void> => {
   const result = EmployeeRegisterT.decode(props.employeeRegister);
   if (isLeft(result)) {
-    throw new Error(`Failed to decode employee register ${JSON.stringify(props)}`);
+    throw new Error(
+      `Failed to decode employee register ${JSON.stringify(props)}`
+    );
   }
   const reqBody = JSON.stringify(result.right);
   const hashedBody = await calculateSha256HashBrowser(reqBody);
@@ -48,17 +56,18 @@ const employeeRegisterFetcher = async (props: EmployeeRegisterContainerProps): P
   const body = await response.json();
   const decoded = EmployeeT.decode(body);
   if (isLeft(decoded)) {
-    throw new Error(`Failed to decode registered employee ${JSON.stringify(body)}`);
+    throw new Error(
+      `Failed to decode registered employee ${JSON.stringify(body)}`
+    );
   }
   alert("登録が完了しました");
-  window.location.href = `/`
-}
+  window.location.href = `/`;
+};
 
 export function EmployeeRegisterContainer() {
-
   return (
     <Box>
-      <EmployeeRegisterItem onSubmit={employeeRegisterFetcher}/>
+      <EmployeeRegisterItem onSubmit={employeeRegisterFetcher} />
     </Box>
-  )
+  );
 }

--- a/frontend/src/components/EmployeeRegisterItem.tsx
+++ b/frontend/src/components/EmployeeRegisterItem.tsx
@@ -1,0 +1,90 @@
+import { useState } from "react";
+import { Paper, Button, TextField } from "@mui/material";
+import { EmployeeRegisterContainerProps } from "./EmployeeRegisterContainer";
+import { EmployeeRegister } from "@/models/Employee";
+
+
+interface EmployeeRegisterProps {
+  onSubmit: (props: EmployeeRegisterContainerProps) => Promise<void>
+}
+
+export function EmployeeRegisterItem({onSubmit}:EmployeeRegisterProps) {
+   const [nameValue, setNameValue] = useState("");
+  const [ageValue, setAgeValue] = useState(0);
+  const [affiliationValue, setAffiliationValue] = useState("");
+  const [positionValue, setPositionValue] = useState("");
+
+  const handleSubmit = async () => {
+    if (!nameValue || ageValue <= 0 || !affiliationValue || !positionValue) {
+      alert("すべての項目を入力してください。年齢は1以上で入力してください。");
+      return;
+    }
+
+    const employeeDataToRegister: EmployeeRegister = {
+      name: nameValue,
+      age: ageValue,
+      affiliation: affiliationValue,
+      position: positionValue,
+    };
+
+    onSubmit({
+      employeeRegister: employeeDataToRegister
+    });
+  };
+
+  return (
+    <Paper sx={{ p: 4, mx: 'auto', mt: 4 }}>
+      <h2>社員登録</h2>
+      <TextField
+        fullWidth
+        label="名前"
+        name="name"
+        placeholder="名前を入力してください"
+        type="text"
+        value={nameValue}
+        onChange={(e) => setNameValue(e.target.value)}
+        margin="normal"
+      />
+      <TextField
+        fullWidth
+        label="年齢"
+        name="age"
+        type="number"
+        value={ageValue === 0 ? "" : ageValue}
+        onChange={(e) => {
+          const value = parseInt(e.target.value);
+          setAgeValue(isNaN(value) ? 0 : value);
+        }}
+        margin="normal"
+      />
+      <TextField
+        fullWidth
+        label="所属"
+        name="affiliation"
+        placeholder="所属部署を入力してください"
+        type="text"
+        value={affiliationValue}
+        onChange={(e) => setAffiliationValue(e.target.value)}
+        margin="normal"
+      />
+      <TextField
+        fullWidth
+        label="役職"
+        name="position"
+        placeholder="役職を入力してください"
+        type="text"
+        value={positionValue}
+        onChange={(e) => setPositionValue(e.target.value)}
+        margin="normal"
+      />
+      <Button
+        variant="contained"
+        fullWidth
+        onClick={handleSubmit}
+        sx={{ mt: 3 }}
+      >
+        登録
+      </Button>
+    </Paper>
+  )
+}

--- a/frontend/src/components/EmployeeRegisterItem.tsx
+++ b/frontend/src/components/EmployeeRegisterItem.tsx
@@ -3,13 +3,12 @@ import { Paper, Button, TextField } from "@mui/material";
 import { EmployeeRegisterContainerProps } from "./EmployeeRegisterContainer";
 import { EmployeeRegister } from "@/models/Employee";
 
-
 interface EmployeeRegisterProps {
-  onSubmit: (props: EmployeeRegisterContainerProps) => Promise<void>
+  onSubmit: (props: EmployeeRegisterContainerProps) => Promise<void>;
 }
 
-export function EmployeeRegisterItem({onSubmit}:EmployeeRegisterProps) {
-   const [nameValue, setNameValue] = useState("");
+export function EmployeeRegisterItem({ onSubmit }: EmployeeRegisterProps) {
+  const [nameValue, setNameValue] = useState("");
   const [ageValue, setAgeValue] = useState(0);
   const [affiliationValue, setAffiliationValue] = useState("");
   const [positionValue, setPositionValue] = useState("");
@@ -28,12 +27,12 @@ export function EmployeeRegisterItem({onSubmit}:EmployeeRegisterProps) {
     };
 
     onSubmit({
-      employeeRegister: employeeDataToRegister
+      employeeRegister: employeeDataToRegister,
     });
   };
 
   return (
-    <Paper sx={{ p: 4, mx: 'auto', mt: 4 }}>
+    <Paper sx={{ p: 4, mx: "auto", mt: 4 }}>
       <h2>社員登録</h2>
       <TextField
         fullWidth
@@ -86,5 +85,5 @@ export function EmployeeRegisterItem({onSubmit}:EmployeeRegisterProps) {
         登録
       </Button>
     </Paper>
-  )
+  );
 }

--- a/frontend/src/components/SearchEmployees.tsx
+++ b/frontend/src/components/SearchEmployees.tsx
@@ -2,6 +2,7 @@
 import FormatListBulletedIcon from "@mui/icons-material/FormatListBulleted";
 import ViewModuleIcon from "@mui/icons-material/ViewModule";
 import {
+  Button,
   FormControl,
   Grid,
   InputLabel,
@@ -48,6 +49,12 @@ export function SearchEmployees() {
           p: 2,
         }}
       >
+       <Button
+        href="/employee/register"
+        style={{ textDecoration: "none" }}
+       >
+        新規作成
+       </Button>
         <TextField
           placeholder="検索キーワードを入力してください"
           value={searchKeyword}

--- a/frontend/src/components/SearchEmployees.tsx
+++ b/frontend/src/components/SearchEmployees.tsx
@@ -49,12 +49,9 @@ export function SearchEmployees() {
           p: 2,
         }}
       >
-       <Button
-        href="/employee/register"
-        style={{ textDecoration: "none" }}
-       >
-        新規作成
-       </Button>
+        <Button href="/employee/register" style={{ textDecoration: "none" }}>
+          新規作成
+        </Button>
         <TextField
           placeholder="検索キーワードを入力してください"
           value={searchKeyword}

--- a/frontend/src/models/Employee.ts
+++ b/frontend/src/models/Employee.ts
@@ -9,3 +9,12 @@ export const EmployeeT = t.type({
 });
 
 export type Employee = t.TypeOf<typeof EmployeeT>;
+
+export const EmployeeRegisterT = t.type({
+    name: t.string,
+    age: t.number,
+    affiliation: t.string,
+    position: t.string,
+});
+
+export type EmployeeRegister = t.TypeOf<typeof EmployeeRegisterT>;


### PR DESCRIPTION
# 概要
社員の新規登録機能追加。
# 詳細
新規作成画面の作成。
名前、年齢、所属、役職、を入力し、自動採番で登録可能。
# 生成AIの利用について
`EmployeeRegisterItem.ts` のUIのレイアウトを調整に利用しました。
<img width="2414" height="1478" alt="image" src="https://github.com/user-attachments/assets/6ca9c1d7-3261-4632-b45d-2a74caf66426" />

