### PR TITLE
Task<10>:<ページネーション・遅延ロードの実装>

### DIFF
--- a/backend-ts/src/employee/EmployeeDatabase.ts
+++ b/backend-ts/src/employee/EmployeeDatabase.ts
@@ -1,6 +1,15 @@
+import { EmployeeApiResponse } from "../types/EmployeeApiResponse";
+import { SortMethod } from "../types/SortMethod";
 import { Employee } from "./Employee";
 
 export interface EmployeeDatabase {
-    getEmployee(id: string): Promise<Employee | undefined>
-    getEmployees(filterText: string, affiliation: string, position: string): Promise<Employee[]>
+  getEmployee(id: string): Promise<Employee | undefined>;
+  getEmployees(
+    filterText: string,
+    affiliation: string,
+    position: string,
+    viewMode: string,
+    sortMethod: SortMethod,
+    pageNo: number
+  ): Promise<EmployeeApiResponse>;
 }

--- a/backend-ts/src/employee/EmployeeDatabaseDynamoDB.ts
+++ b/backend-ts/src/employee/EmployeeDatabaseDynamoDB.ts
@@ -1,75 +1,110 @@
-import { DynamoDBClient, GetItemCommand, GetItemCommandInput, ScanCommand, ScanCommandInput } from "@aws-sdk/client-dynamodb";
+import {
+  DynamoDBClient,
+  GetItemCommand,
+  GetItemCommandInput,
+  ScanCommand,
+  ScanCommandInput,
+} from "@aws-sdk/client-dynamodb";
 import { isLeft } from "fp-ts/Either";
 import { EmployeeDatabase } from "./EmployeeDatabase";
 import { Employee, EmployeeT } from "./Employee";
+import { pageRow } from "../types/PageNo";
+import { SortMethod } from "../types/SortMethod";
+import { EmployeeApiResponse } from "../types/EmployeeApiResponse";
 
 export class EmployeeDatabaseDynamoDB implements EmployeeDatabase {
-    private client: DynamoDBClient;
-    private tableName: string;
+  private client: DynamoDBClient;
+  private tableName: string;
 
-    constructor(client: DynamoDBClient, tableName: string) {
-        this.client = client;
-        this.tableName = tableName;
+  constructor(client: DynamoDBClient, tableName: string) {
+    this.client = client;
+    this.tableName = tableName;
+  }
+
+  async getEmployee(id: string): Promise<Employee | undefined> {
+    const input: GetItemCommandInput = {
+      TableName: this.tableName,
+      Key: {
+        id: { S: id },
+      },
+    };
+    const output = await this.client.send(new GetItemCommand(input));
+    const item = output.Item;
+    if (item == null) {
+      return;
     }
+    const employee = {
+      id: id,
+      name: item["name"].S,
+      age: mapNullable(item["age"].N, (value) => parseInt(value, 10)),
+    };
+    const decoded = EmployeeT.decode(employee);
+    if (isLeft(decoded)) {
+      throw new Error(
+        `Employee ${id} is missing some fields. ${JSON.stringify(employee)}`
+      );
+    } else {
+      return decoded.right;
+    }
+  }
 
-    async getEmployee(id: string): Promise<Employee | undefined> {
-        const input: GetItemCommandInput  = {
-            TableName: this.tableName,
-            Key: {
-                id: { S: id },
-            },
+  async getEmployees(
+    filterText: string,
+    affiliation: string,
+    position: string,
+    viewMode: string,
+    sortMethod: SortMethod,
+    pageNo: number
+  ): Promise<EmployeeApiResponse> {
+    const input: ScanCommandInput = {
+      TableName: this.tableName,
+    };
+    const output = await this.client.send(new ScanCommand(input));
+    const items = output.Items;
+    if (items == null) {
+      return {
+        employees: [],
+        totalPages: 0,
+      };
+    }
+    const employees = items
+      .filter((item) => filterText === "" || item["name"].S === filterText)
+      .filter(
+        (item) => affiliation === "" || item["affiliation"].S === affiliation
+      )
+      .filter((item) => position === "" || item["position"].S === position)
+      .map((item) => {
+        return {
+          id: item["id"].S,
+          name: item["name"].S,
+          age: mapNullable(item["age"].N, (value) => parseInt(value, 10)),
         };
-        const output = await this.client.send(new GetItemCommand(input));
-        const item = output.Item;
-        if (item == null) {
-            return;
-        }
-        const employee = {
-            id: id,
-            name: item["name"].S,
-            age: mapNullable(item["age"].N, value => parseInt(value, 10)),
-        };
+      })
+      .flatMap((employee) => {
         const decoded = EmployeeT.decode(employee);
         if (isLeft(decoded)) {
-            throw new Error(`Employee ${id} is missing some fields. ${JSON.stringify(employee)}`);
+          console.error(
+            `Employee ${employee.id} is missing some fields and skipped. ${JSON.stringify(employee)}`
+          );
+          return [];
         } else {
-            return decoded.right;
+          return [decoded.right];
         }
-    }
+      });
 
-    async getEmployees(filterText: string, affiliation: string, position: string): Promise<Employee[]> {
-        const input: ScanCommandInput  = {
-            TableName: this.tableName,
-        };
-        const output = await this.client.send(new ScanCommand(input));
-        const items = output.Items;
-        if (items == null) {
-            return [];
-        }
-        return items
-            .filter(item => filterText === "" || item["name"].S === filterText)
-            .filter(item => affiliation === "" || item["affiliation"].S === affiliation)
-            .filter(item => position === "" || item["position"].S === position)
-            .map(item => {
-                return {
-                    id: item["id"].S,
-                    name: item["name"].S,
-                    age: mapNullable(item["age"].N, value => parseInt(value, 10)),
-                }
-            }).flatMap(employee => {
-                const decoded = EmployeeT.decode(employee);
-                if (isLeft(decoded)) {
-                    console.error(`Employee ${employee.id} is missing some fields and skipped. ${JSON.stringify(employee)}`);
-                    return [];
-                } else {
-                    return [decoded.right];
-                }
-            });
-    }
+    const totalPages = Math.ceil(employees.length / pageRow(viewMode));
+    return {
+      employees: employees,
+      totalPages: totalPages,
+    };
+  }
 }
 
-function mapNullable<T, U>(value: T | null | undefined, mapper: (value: T) => U): U | undefined {
-    if (value != null) {
-        return mapper(value);
-    }
+function mapNullable<T, U>(
+  value: T | null | undefined,
+  mapper: (value: T) => U
+): U | undefined {
+  if (value != null) {
+    return mapper(value);
+  }
 }

--- a/backend-ts/src/employee/EmployeeDatabaseInMemory.ts
+++ b/backend-ts/src/employee/EmployeeDatabaseInMemory.ts
@@ -1,35 +1,153 @@
 import { EmployeeDatabase } from "./EmployeeDatabase";
 import { Employee } from "./Employee";
+import { SortMethod } from "../types/SortMethod";
+import { EmployeeApiResponse } from "../types/EmployeeApiResponse";
+import { pageRow } from "../types/PageNo";
 
 export class EmployeeDatabaseInMemory implements EmployeeDatabase {
-    private employees: Map<string, Employee>
+  private employees: Map<string, Employee>;
 
-    constructor() {
-        this.employees = new Map<string, Employee>();
-        this.employees.set("1", { id: "1", name: "Jane Doe", age: 22, affiliation: "人事", position: "主任" });
-        this.employees.set("2", { id: "2", name: "John Smith", age: 28, affiliation: "人事", position: "部長" });
-        this.employees.set("3", { id: "3", name: "山田 太郎", age: 27, affiliation: "開発", position: "一般" });
+  constructor() {
+    this.employees = new Map<string, Employee>();
+    this.employees.set("1", {
+      id: "1",
+      name: "Jane Doe",
+      age: 22,
+      affiliation: "人事",
+      position: "主任",
+    });
+    this.employees.set("2", {
+      id: "2",
+      name: "John Smith",
+      age: 28,
+      affiliation: "人事",
+      position: "部長",
+    });
+    this.employees.set("3", {
+      id: "3",
+      name: "山田 太郎1",
+      age: 117,
+      affiliation: "開発",
+      position: "一般",
+    });
+    this.employees.set("4", {
+      id: "4",
+      name: "山田 太郎2",
+      age: 107,
+      affiliation: "開発",
+      position: "一般",
+    });
+    this.employees.set("5", {
+      id: "5",
+      name: "山田 太郎3",
+      age: 97,
+      affiliation: "開発",
+      position: "一般",
+    });
+    this.employees.set("6", {
+      id: "6",
+      name: "山田 太郎4",
+      age: 87,
+      affiliation: "開発",
+      position: "一般",
+    });
+    this.employees.set("7", {
+      id: "7",
+      name: "山田 太郎5",
+      age: 77,
+      affiliation: "開発",
+      position: "一般",
+    });
+    this.employees.set("8", {
+      id: "8",
+      name: "山田 太郎6",
+      age: 67,
+      affiliation: "開発",
+      position: "一般",
+    });
+    this.employees.set("9", {
+      id: "9",
+      name: "山田 太郎7",
+      age: 57,
+      affiliation: "開発",
+      position: "一般",
+    });
+    this.employees.set("10", {
+      id: "10",
+      name: "山田 太郎8",
+      age: 47,
+      affiliation: "開発",
+      position: "一般",
+    });
+    this.employees.set("11", {
+      id: "11",
+      name: "山田 太郎9",
+      age: 37,
+      affiliation: "開発",
+      position: "一般",
+    });
+  }
+
+  async getEmployee(id: string): Promise<Employee | undefined> {
+    return this.employees.get(id);
+  }
+
+  async getEmployees(
+    filterText: string,
+    affiliation: string,
+    position: string,
+    viewMode: string,
+    sortMethod: SortMethod,
+    pageNo: number
+  ): Promise<EmployeeApiResponse> {
+    let employees = Array.from(this.employees.values());
+
+    if (filterText !== "") {
+      employees = employees.filter((employee) =>
+        employee.name.includes(filterText)
+      );
     }
 
-    async getEmployee(id: string): Promise<Employee | undefined> {
-        return this.employees.get(id);
+    if (affiliation !== "") {
+      employees = employees.filter(
+        (employee) => employee.affiliation === affiliation
+      );
     }
 
-    async getEmployees(filterText: string, affiliation: string, position: string): Promise<Employee[]> {
-        let employees = Array.from(this.employees.values());
-
-        if (filterText !== "") {
-            employees = employees.filter(employee => employee.name.includes(filterText));
-        }
-
-        if (affiliation !== "") {
-            employees = employees.filter(employee => employee.affiliation === affiliation);
-        }
-
-        if (position !== "") {
-            employees = employees.filter(employee => employee.position === position);
-        }
-
-        return employees;
+    if (position !== "") {
+      employees = employees.filter(
+        (employee) => employee.position === position
+      );
     }
+
+    switch (sortMethod) {
+      case "age-asc":
+        employees.sort((a, b) => a.age - b.age);
+        break;
+      case "age-dsc":
+        employees.sort((a, b) => b.age - a.age);
+        break;
+      case "name-asc":
+        employees.sort((a, b) => a.name.localeCompare(b.name));
+        break;
+      case "name-desc":
+        employees.sort((a, b) => b.name.localeCompare(a.name));
+        break;
+      default:
+        break;
+    }
+
+    const sortedDataLength = employees.length;
+    const row = pageRow(viewMode);
+    const startIndex = (pageNo - 1) * row;
+    const endIndex =
+      startIndex + row > sortedDataLength ? sortedDataLength : startIndex + row;
+    const paginatedEmployees = employees.slice(startIndex, endIndex);
+
+    const totalPages = Math.ceil(employees.length / row);
+    return {
+      employees: paginatedEmployees,
+      totalPages: totalPages,
+    };
+  }
 }

--- a/backend-ts/src/index.ts
+++ b/backend-ts/src/index.ts
@@ -1,45 +1,73 @@
 import express, { Request, Response } from "express";
-import { EmployeeDatabaseInMemory } from './employee/EmployeeDatabaseInMemory';
-import {isValidQueryString} from "./utils/validator";
+import { EmployeeDatabaseInMemory } from "./employee/EmployeeDatabaseInMemory";
+import { isValidQueryString } from "./utils/validator";
+import { ParsedQs } from "qs";
+import { SortMethod } from "./types/SortMethod";
 
 const app = express();
 const port = process.env.PORT ?? 8080;
 const database = new EmployeeDatabaseInMemory();
 
 app.get("/api/employees", async (req: Request, res: Response) => {
-    const filterText = req.query.filterText ?? "";
-    const affiliation = req.query.affiliation ?? "";
-    const position = req.query.position ?? "";
-
-    if (!isValidQueryString(filterText) || !isValidQueryString(affiliation) || !isValidQueryString(position)) {
-        res.status(400).send();
-        return;
+  const filterText = req.query.filterText ?? "";
+  const affiliation = req.query.affiliation ?? "";
+  const position = req.query.position ?? "";
+  const viewMode = req.query.viewMode ?? "";
+  const sortMethod =
+    (req.query.sortMethod as SortMethod) ?? ("default" as SortMethod);
+  const parsePageNo = (
+    value: string | ParsedQs | (string | ParsedQs)[] | undefined
+  ): number => {
+    if (typeof value === "string") {
+      const parsed = parseInt(value, 10);
+      return isNaN(parsed) ? 1 : parsed;
     }
+    return 1;
+  };
 
-    try {
-        const employees = await database.getEmployees(filterText, affiliation, position);
-        res.status(200).send(JSON.stringify(employees));
-    } catch (e) {
-        console.error(`Failed to load the users filtered by ${filterText}.`, e);
-        res.status(500).send();
-    }
+  const pageNo = parsePageNo(req.query.pageNo);
+
+  if (
+    !isValidQueryString(filterText) ||
+    !isValidQueryString(affiliation) ||
+    !isValidQueryString(position) ||
+    !isValidQueryString(viewMode)
+  ) {
+    res.status(400).send();
+    return;
+  }
+
+  try {
+    const employees = await database.getEmployees(
+      filterText,
+      affiliation,
+      position,
+      viewMode,
+      sortMethod,
+      pageNo
+    );
+    res.status(200).send(JSON.stringify(employees));
+  } catch (e) {
+    console.error(`Failed to load the users filtered by ${filterText}.`, e);
+    res.status(500).send();
+  }
 });
 
 app.get("/api/employees/:userId", async (req: Request, res: Response) => {
-    const userId = req.params.userId;
-    try {
-        const employee = await database.getEmployee(userId);
-        if (employee == undefined) {
-            res.status(404).send();
-            return;
-        }
-        res.status(200).send(JSON.stringify(employee));
-    } catch (e) {
-        console.error(`Failed to load the user ${userId}.`, e);
-        res.status(500).send();
+  const userId = req.params.userId;
+  try {
+    const employee = await database.getEmployee(userId);
+    if (employee == undefined) {
+      res.status(404).send();
+      return;
     }
+    res.status(200).send(JSON.stringify(employee));
+  } catch (e) {
+    console.error(`Failed to load the user ${userId}.`, e);
+    res.status(500).send();
+  }
 });
 
 app.listen(port, () => {
-    console.log(`App listening on the port ${port}`);
+  console.log(`App listening on the port ${port}`);
 });

--- a/backend-ts/src/types/EmployeeApiResponse.ts
+++ b/backend-ts/src/types/EmployeeApiResponse.ts
@@ -1,0 +1,6 @@
+import { Employee } from "../employee/Employee";
+
+export type EmployeeApiResponse = {
+  employees: Employee[];
+  totalPages: number;
+};

--- a/backend-ts/src/types/PageNo.ts
+++ b/backend-ts/src/types/PageNo.ts
@@ -1,0 +1,7 @@
+export const pageRow = (viewMode: string) => {
+  if (viewMode == "card") {
+    return 9;
+  }
+
+  return 4;
+};

--- a/backend-ts/src/types/SortMethod.ts
+++ b/backend-ts/src/types/SortMethod.ts
@@ -1,0 +1,6 @@
+export type SortMethod =
+  | "default"
+  | "age-asc"
+  | "age-dsc"
+  | "name-asc"
+  | "name-desc";

--- a/backend-ts/tsconfig.json
+++ b/backend-ts/tsconfig.json
@@ -11,7 +11,7 @@
     // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
 
     /* Language and Environment */
-    "target": "es2016",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
+    "target": "es2016" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
     // "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
     // "jsx": "preserve",                                /* Specify what JSX code is generated. */
     // "libReplacement": true,                           /* Enable lib replacement. */
@@ -26,8 +26,8 @@
     // "moduleDetection": "auto",                        /* Control what method is used to detect module-format JS files. */
 
     /* Modules */
-    "module": "commonjs",                                /* Specify what module code is generated. */
-    "rootDir": "./src",                                  /* Specify the root folder within your source files. */
+    "module": "commonjs" /* Specify what module code is generated. */,
+    "rootDir": "./src" /* Specify the root folder within your source files. */,
     // "moduleResolution": "node10",                     /* Specify how TypeScript looks up a file from a given module specifier. */
     // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
     // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
@@ -59,7 +59,7 @@
     // "inlineSourceMap": true,                          /* Include sourcemap files inside the emitted JavaScript. */
     // "noEmit": true,                                   /* Disable emitting files from a compilation. */
     // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */
-    "outDir": "./out",                                   /* Specify an output folder for all emitted files. */
+    "outDir": "./out" /* Specify an output folder for all emitted files. */,
     // "removeComments": true,                           /* Disable emitting comments. */
     // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */
     // "downlevelIteration": true,                       /* Emit more compliant, but verbose and less performant JavaScript for iteration. */
@@ -80,12 +80,12 @@
     // "isolatedDeclarations": true,                     /* Require sufficient annotation on exports so other tools can trivially generate declaration files. */
     // "erasableSyntaxOnly": true,                       /* Do not allow runtime constructs that are not part of ECMAScript. */
     // "allowSyntheticDefaultImports": true,             /* Allow 'import x from y' when a module doesn't have a default export. */
-    "esModuleInterop": true,                             /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */
+    "esModuleInterop": true /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */,
     // "preserveSymlinks": true,                         /* Disable resolving symlinks to their realpath. This correlates to the same flag in node. */
-    "forceConsistentCasingInFileNames": true,            /* Ensure that casing is correct in imports. */
+    "forceConsistentCasingInFileNames": true /* Ensure that casing is correct in imports. */,
 
     /* Type Checking */
-    "strict": true,                                      /* Enable all strict type-checking options. */
+    "strict": true /* Enable all strict type-checking options. */,
     // "noImplicitAny": true,                            /* Enable error reporting for expressions and declarations with an implied 'any' type. */
     // "strictNullChecks": true,                         /* When type checking, take into account 'null' and 'undefined'. */
     // "strictFunctionTypes": true,                      /* When assigning functions, check to ensure parameters and the return values are subtype-compatible. */
@@ -108,6 +108,6 @@
 
     /* Completeness */
     // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
-    "skipLibCheck": true                                 /* Skip type checking all .d.ts files. */
+    "skipLibCheck": true /* Skip type checking all .d.ts files. */
   }
 }

--- a/frontend/src/components/SearchEmployees.tsx
+++ b/frontend/src/components/SearchEmployees.tsx
@@ -108,16 +108,18 @@ export function SearchEmployees() {
           </ToggleButton>
         </ToggleButtonGroup>
 
-        <EmployeeListContainer
-          key="employeesContainer"
-          filterText={searchKeyword}
-          affiliationFilter={affiliationFilter}
-          positionFilter={positionFilter}
-          sortMethod={sortMethod}
-          viewMode={viewMode}
-          pageNo={pageNo}
-          onTotalPagesChange={setTotalPages}
-        />
+        <Box sx={{ minHeight: "420px" }}>
+          <EmployeeListContainer
+            key="employeesContainer"
+            filterText={searchKeyword}
+            affiliationFilter={affiliationFilter}
+            positionFilter={positionFilter}
+            sortMethod={sortMethod}
+            viewMode={viewMode}
+            pageNo={pageNo}
+            onTotalPagesChange={setTotalPages}
+          />
+        </Box>
 
         <Box
           sx={{

--- a/frontend/src/components/SearchEmployees.tsx
+++ b/frontend/src/components/SearchEmployees.tsx
@@ -2,10 +2,12 @@
 import FormatListBulletedIcon from "@mui/icons-material/FormatListBulleted";
 import ViewModuleIcon from "@mui/icons-material/ViewModule";
 import {
+  Box,
   FormControl,
   Grid,
   InputLabel,
   MenuItem,
+  Pagination,
   Paper,
   Select,
   SelectChangeEvent,
@@ -13,7 +15,7 @@ import {
   ToggleButton,
   ToggleButtonGroup,
 } from "@mui/material";
-import { useState } from "react";
+import React, { useState } from "react";
 import { EmployeeListContainer, SortMethod } from "./EmployeeListContainer";
 
 export function SearchEmployees() {
@@ -21,6 +23,8 @@ export function SearchEmployees() {
   const [affiliationFilter, setAffiliationFilter] = useState("");
   const [positionFilter, setPositionFilter] = useState("");
   const [sortMethod, setSortMethod] = useState<SortMethod>("default");
+  const [pageNo, setPageNo] = useState(1);
+  const [totalPages, setTotalPages] = useState(1);
 
   const handleSortMethodSelected = (event: SelectChangeEvent) => {
     setSortMethod(event.target.value as SortMethod);
@@ -111,7 +115,26 @@ export function SearchEmployees() {
           positionFilter={positionFilter}
           sortMethod={sortMethod}
           viewMode={viewMode}
+          pageNo={pageNo}
+          onTotalPagesChange={setTotalPages}
         />
+
+        <Box
+          sx={{
+            display: "flex",
+            justifyContent: "center",
+            mt: 2,
+            mb: 2,
+          }}
+        >
+          <Pagination
+            count={totalPages}
+            page={pageNo}
+            onChange={(_: React.ChangeEvent<unknown>, newPageNo: number) =>
+              setPageNo(newPageNo)
+            }
+          />
+        </Box>
       </Paper>
     </>
   );

--- a/frontend/src/types/EmployeeApiResponse.ts
+++ b/frontend/src/types/EmployeeApiResponse.ts
@@ -1,0 +1,6 @@
+import { Employee } from "@/models/Employee";
+
+export type EmployeeApiResponse = {
+  employees: Employee[];
+  totalPages: number;
+};


### PR DESCRIPTION
# 概要
検索画面にページネーション・遅延ロードを実装しました。

# 詳細
人材データをバックエンドで必要な数だけ読み込むことによって、総数に依らず高速な画面表示が可能になりました。リスト形式のときは4件/頁、カード形式の時は9件/頁になるように設計しました。これは、ページ遷移（ページ番号）ボタンをデータの件数に依らず固定したときに、収まる最大の数です。本来、型定義をバックエンドとフロントエンドで共有するべきでしたが、時間的要因から今回は個別に同じものを定義して動作させることとしました。