### PR TITLE
従業員詳細ページのidの指定をパスパラメータに変更

### DIFF
--- a/backend-ts/src/employee/EmployeeDatabaseInMemory.ts
+++ b/backend-ts/src/employee/EmployeeDatabaseInMemory.ts
@@ -3,6 +3,7 @@ import { Employee, EmployeeRegister } from "./Employee";
 import { SortMethod } from "../types/SortMethod";
 import { EmployeeApiResponse } from "../types/EmployeeApiResponse";
 import { pageRow } from "../types/PageNo";
+import e from "express";
 
 export class EmployeeDatabaseInMemory implements EmployeeDatabase {
   private employees: Map<string, Employee>;

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -3,7 +3,7 @@ import type { NextConfig } from "next";
 const nextConfig: NextConfig = {
   /* config options here */
   // Settings for single page app
-  output: "export", // Depends on how we deploy the app
+  // output: "export", // Depends on how we deploy the app 
   // Proxy API calls in case of SPA.
   async rewrites() {
     return [

--- a/frontend/src/app/employee/[id]/page.tsx
+++ b/frontend/src/app/employee/[id]/page.tsx
@@ -9,7 +9,7 @@ export default async function EmployeePage({
   params: Promise<{ id: string }>; // 非同期で取得する
 }) {
   const { id } = await params;
-  
+
   return (
     <GlobalContainer pageName={"社員詳細"}>
       {/* Mark EmployeeDetailsContainer as CSR */}

--- a/frontend/src/app/employee/[id]/page.tsx
+++ b/frontend/src/app/employee/[id]/page.tsx
@@ -3,12 +3,18 @@ import { EmployeeDetailsContainer } from "@/components/EmployeeDetailsContainer"
 import { GlobalContainer } from "@/components/GlobalContainer";
 import { Suspense } from "react";
 
-export default function EmployeePage({ params }: { params: { id: string } }) {
+export default async function EmployeePage({
+  params,
+}: {
+  params: Promise<{ id: string }>; // 非同期で取得する
+}) {
+  const { id } = await params;
+  
   return (
     <GlobalContainer pageName={"社員詳細"}>
       {/* Mark EmployeeDetailsContainer as CSR */}
       <Suspense>
-        <EmployeeDetailsContainer id={params.id} />
+        <EmployeeDetailsContainer id={id} />
       </Suspense>
       <BackButton text={"検索画面に戻る"} />
     </GlobalContainer>

--- a/frontend/src/app/employee/[id]/page.tsx
+++ b/frontend/src/app/employee/[id]/page.tsx
@@ -3,8 +3,7 @@ import { EmployeeDetailsContainer } from "@/components/EmployeeDetailsContainer"
 import { GlobalContainer } from "@/components/GlobalContainer";
 import { Suspense } from "react";
 
-
-export default function EmployeePage({params}: {params: {id: string}}) {
+export default function EmployeePage({ params }: { params: { id: string } }) {
   return (
     <GlobalContainer pageName={"社員詳細"}>
       {/* Mark EmployeeDetailsContainer as CSR */}

--- a/frontend/src/app/employee/[id]/page.tsx
+++ b/frontend/src/app/employee/[id]/page.tsx
@@ -3,12 +3,13 @@ import { EmployeeDetailsContainer } from "@/components/EmployeeDetailsContainer"
 import { GlobalContainer } from "@/components/GlobalContainer";
 import { Suspense } from "react";
 
-export default function EmployeePage() {
+
+export default function EmployeePage({params}: {params: {id: string}}) {
   return (
     <GlobalContainer pageName={"社員詳細"}>
       {/* Mark EmployeeDetailsContainer as CSR */}
       <Suspense>
-        <EmployeeDetailsContainer />
+        <EmployeeDetailsContainer id={params.id} />
       </Suspense>
       <BackButton text={"検索画面に戻る"} />
     </GlobalContainer>

--- a/frontend/src/components/EmployeeDetailsContainer.tsx
+++ b/frontend/src/components/EmployeeDetailsContainer.tsx
@@ -3,7 +3,6 @@ import { useEffect } from "react";
 import useSWR from "swr";
 import { isLeft } from "fp-ts/Either";
 import { Employee, EmployeeT } from "../models/Employee";
-import { useSearchParams } from "next/navigation";
 import { EmployeeDetails } from "./EmployeeDetails";
 
 const employeeFetcher = async (url: string): Promise<Employee> => {
@@ -18,9 +17,12 @@ const employeeFetcher = async (url: string): Promise<Employee> => {
   }
   return decoded.right;
 };
+export interface EmployeeDetailsContainerProps {
+  id: string;
+}
 
-export function EmployeeDetailsContainer() {
-  const id = useSearchParams().get("id");
+
+export function EmployeeDetailsContainer({id}: EmployeeDetailsContainerProps) {
 
   const { data, error, isLoading } = useSWR<Employee, Error>(
     `/api/employees/${id}`,

--- a/frontend/src/components/EmployeeDetailsContainer.tsx
+++ b/frontend/src/components/EmployeeDetailsContainer.tsx
@@ -21,9 +21,9 @@ export interface EmployeeDetailsContainerProps {
   id: string;
 }
 
-
-export function EmployeeDetailsContainer({id}: EmployeeDetailsContainerProps) {
-
+export function EmployeeDetailsContainer({
+  id,
+}: EmployeeDetailsContainerProps) {
   const { data, error, isLoading } = useSWR<Employee, Error>(
     `/api/employees/${id}`,
     employeeFetcher

--- a/frontend/src/components/EmployeeListItem.tsx
+++ b/frontend/src/components/EmployeeListItem.tsx
@@ -21,10 +21,7 @@ export function EmployeeListItem({
   viewMode,
 }: EmployeeListItemProps) {
   return (
-    <Link
-      href={`/employee/${employee.id}`}
-      style={{ textDecoration: "none" }}
-    >
+    <Link href={`/employee/${employee.id}`} style={{ textDecoration: "none" }}>
       <Card
         sx={{
           transition: "background-color 0.2s",

--- a/frontend/src/components/EmployeeListItem.tsx
+++ b/frontend/src/components/EmployeeListItem.tsx
@@ -22,7 +22,7 @@ export function EmployeeListItem({
 }: EmployeeListItemProps) {
   return (
     <Link
-      href={`/employee?id=${employee.id}`}
+      href={`/employee/${employee.id}`}
       style={{ textDecoration: "none" }}
     >
       <Card


### PR DESCRIPTION
# 概要
従業員詳細ページのIDの指定がクエリパラメータでされていたものを、パスパラメータに変更しました。
# 詳細
- `employee/page.tsx`を`employee/[id]/page.tsx`に移動し、パスパラメータでの受け取りに変更しました。
- 動的なページ生成が必要になったため、`next.config.ts`内の`output: "export"`設定を無効にしました。